### PR TITLE
Add optional AT router to Cloud Object Storage

### DIFF
--- a/admin-setup/main.tf
+++ b/admin-setup/main.tf
@@ -127,9 +127,9 @@ resource "ibm_iam_authorization_policy" "atracker_policy" {
 resource "ibm_atracker_target" "atracker_cos_target" {
   count = var.use_cos_for_at ? 1 : 0
   cos_endpoint {
-     endpoint = ibm_cos_bucket.at-events-smart-us-south-rand.s3_endpoint_public
+     endpoint = ibm_cos_bucket.at-events-smart-us-south-rand[0].s3_endpoint_public
      target_crn = ibm_resource_instance.cos_instance.crn
-     bucket = ibm_cos_bucket.at-events-smart-us-south-rand.bucket_name
+     bucket = ibm_cos_bucket.at-events-smart-us-south-rand[0].bucket_name
   }
   name = "at-cos-target-us-south"
   target_type = "cloud_object_storage"
@@ -141,7 +141,7 @@ resource "ibm_atracker_route" "atracker_cos_route" {
   count = var.use_cos_for_at ? 1 : 0
   name = "atracker-cos-route"
   rules {
-    target_ids = [ ibm_atracker_target.atracker_cos_target.id ]
+    target_ids = [ ibm_atracker_target.atracker_cos_target[0].id ]
     locations = [ "us-south", "eu-de", "global" ]
   }
   lifecycle {

--- a/admin-setup/main.tf
+++ b/admin-setup/main.tf
@@ -130,6 +130,7 @@ resource "ibm_atracker_target" "atracker_cos_target" {
      endpoint = ibm_cos_bucket.at-events-smart-us-south-rand[0].s3_endpoint_public
      target_crn = ibm_resource_instance.cos_instance.crn
      bucket = ibm_cos_bucket.at-events-smart-us-south-rand[0].bucket_name
+     service_to_service_enabled = true 
   }
   name = "at-cos-target-us-south"
   target_type = "cloud_object_storage"
@@ -156,7 +157,7 @@ resource "ibm_iam_authorization_policy" "atracker_cos_policy" {
   source_service_name         = "atracker"
   target_service_name         = "cloud-object-storage"
   target_resource_instance_id = ibm_resource_instance.cos_instance.guid
-  roles                       = ["Writer"]
+  roles                       = ["Object Writer"]
 }
 
 # Add permission from logs router service to cloud logs service instance

--- a/admin-setup/variables.tf
+++ b/admin-setup/variables.tf
@@ -27,3 +27,9 @@ variable "acct_mgr_admins_user_ids" {
   description = "Names of the users to add to the watsonx Admin access group - do not include account owner IBMid"
   default     = [""]
 }
+
+variable "use_cos_for_at" {
+  type = bool
+  description = "Also configure an activity tracker target and route to a cos bucket"
+  default = true
+}


### PR DESCRIPTION
Set up an option to add a COS destination (reusing original instance) for Activity Tracker routing of audit events. Defaults to sending traffic from `us-south`, `eu-de`, and the `global` location to the bucket.